### PR TITLE
ci: use `EmbarkStudios/cargo-deny-action@v1`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -117,9 +117,7 @@ jobs:
           git submodule update --remote --no-recommend-shallow
 
       - name: Audit
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        uses: EmbarkStudios/cargo-deny-action@v1
 
   devskim:
     needs:

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,4 @@
+[licenses]
+version = 2
+allow = ["Apache-2.0", "BSD-2-Clause", "MIT", "Unicode-DFS-2016"]
+private = { ignore = true }


### PR DESCRIPTION
The previously used and now deprecated `actions-rs/audit-check@v1` does not work well anymore, and does not reliably tell you about error before the change was merged.

Related: #6.